### PR TITLE
feat: add support for exceptions, stack frames, proper debug builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
             "properties": {
               "program": {
                 "type": "string",
-                "description": "Absolute path to the elf file",
+                "description": "Absolute path to the project folder (e.g. TestProject.X) to pick up a configuration file from",
                 "default": "${workspaceFolder}/${command:AskForProgramName}"
               },
               "stopOnEntry": {
@@ -139,6 +139,10 @@
               "configuration": {
                 "type": "string",
                 "description": "The configuration of the project to build"
+              },
+              "debug": {
+                "type": "boolean",
+                "description": "Boolean indicating debug build or production build"
               }
             }
           }
@@ -151,7 +155,8 @@
             "program": "${workspaceFolder}/",
             "stopOnEntry": true,
             "preLaunchTask": "MPLABX Build",
-            "configuration": "default"
+            "configuration": "default",
+            "debug": true
           }
         ],
         "configurationSnippets": [
@@ -165,7 +170,8 @@
               "program": "${workspaceFolder}/",
               "stopOnEntry": true,
               "preLaunchTask": "MPLABX Build",
-              "configuration": "default"
+              "configuration": "default",
+              "debug": true
             }
           }
         ],

--- a/package.json
+++ b/package.json
@@ -135,6 +135,10 @@
                 "type": "boolean",
                 "description": "Enable logging of the Debug Adapter Protocol.",
                 "default": true
+              },
+              "configuration": {
+                "type": "string",
+                "description": "The configuration of the project to build"
               }
             }
           }
@@ -146,7 +150,8 @@
             "name": "MPLABX Debug",
             "program": "${workspaceFolder}/",
             "stopOnEntry": true,
-            "preLaunchTask": "MPLABX Build"
+            "preLaunchTask": "MPLABX Build",
+            "configuration": "default"
           }
         ],
         "configurationSnippets": [
@@ -159,7 +164,8 @@
               "name": "MPLABX Debug",
               "program": "${workspaceFolder}/",
               "stopOnEntry": true,
-              "preLaunchTask": "MPLABX Build"
+              "preLaunchTask": "MPLABX Build",
+              "configuration": "default"
             }
           }
         ],
@@ -191,6 +197,10 @@
           "configuration": {
             "type": "string",
             "description": "The configuration of the project to build"
+          },
+          "debug": {
+            "type": "boolean",
+            "description": "Boolean indicating debug build or production build"
           }
         }
       }

--- a/sampleWorkspace/.vscode/launch.json
+++ b/sampleWorkspace/.vscode/launch.json
@@ -10,7 +10,8 @@
             "name": "MPLABX Debug",
             "program": "${workspaceFolder}/TestProject.X",
             "stopOnEntry": true,
-            "preLaunchTask": "MPLABX Build"
+            "preLaunchTask": "MPLABX Build",
+            "debug": true
         }
     ]
 }

--- a/src/common/mdbPaths.ts
+++ b/src/common/mdbPaths.ts
@@ -1,0 +1,4 @@
+import path = require("path");
+
+
+export const normalizePath = (filePath: string) => path.resolve(filePath).toLowerCase();

--- a/src/debugAdapter/mdbCommunications.ts
+++ b/src/debugAdapter/mdbCommunications.ts
@@ -216,7 +216,7 @@ export class MDBCommunications extends EventEmitter {
 
 		if (!matches?.length) return;
 
-		const [_, address, file, line] = matches;
+		const [_, _address, file, line] = matches;
 
 		const breakpoint = this._breakpoints.find(bp => (normalizePath(bp.file) === normalizePath(file)) && bp.line === parseInt(line, 10));
 

--- a/src/debugAdapter/mdbCommunications.ts
+++ b/src/debugAdapter/mdbCommunications.ts
@@ -208,8 +208,9 @@ export class MDBCommunications extends EventEmitter {
 	 * @param initialMessage The initial message containing "Stop at" and potentially more of the data
 	 */
 	private async handleStopAt(initialMessage: string): Promise<void> {
+		const breakpointRegex = /address:(0x.{8})|file:(.+)|source line:(\d+)/gm;
 		let message = initialMessage;
-		let matches = message.match(/address:(0x.{8})|file:(.+)|source line:(\d+)/gm);
+		let matches = message.match(breakpointRegex);
 
 		// Stop at message may or may not come in a single data or over multiple. 
 		// If we don't match the pattern, we need to keep reading and re-parse when a full message has been received.
@@ -218,7 +219,7 @@ export class MDBCommunications extends EventEmitter {
 			message += remainingResult;
 		}
 
-		matches = message.match(/address:(0x.{8})|file:(.+)|source line:(\d+)/gm);
+		matches = message.match(breakpointRegex);
 
 		if (!matches?.length) return;
 

--- a/src/debugAdapter/mdbCommunications.ts
+++ b/src/debugAdapter/mdbCommunications.ts
@@ -205,8 +205,7 @@ export class MDBCommunications extends EventEmitter {
 
 	/**
 	 * Handles a "Stop at" message from output. Swallows responses until entirety of "Stop at" message has been chunked out
-	 * @param initialMessage 
-	 * @returns 
+	 * @param initialMessage The initial message containing "Stop at" and potentially more of the data
 	 */
 	private async handleStopAt(initialMessage: string): Promise<void> {
 		let message = initialMessage;

--- a/src/debugAdapter/mdbCommunications.ts
+++ b/src/debugAdapter/mdbCommunications.ts
@@ -231,7 +231,7 @@ export class MDBCommunications extends EventEmitter {
 			return; // Early return, as stopAt otherwise checks exceptions and breakpoints
 		}
 
-		const breakpointRegex = /address:(0x.{8})|file:(.+)|source line:(\d+)/gm;
+		const breakpointRegex = /address:(0x.{2,8})|file:(.+)|source line:(\d+)/gm;
 		let message = initialMessage;
 		let matches = message.match(breakpointRegex);
 

--- a/src/debugAdapter/mplabxDebug.ts
+++ b/src/debugAdapter/mplabxDebug.ts
@@ -97,13 +97,13 @@ export class MplabxDebugSession extends LoggingDebugSession {
 		// this._runtime.on('stopOnInstructionBreakpoint', () => {
 		// 	this.sendEvent(new StoppedEvent('instruction breakpoint', MplabxDebugSession.threadID,));
 		// });
-		// this._runtime.on('stopOnException', (exception) => {
-		// 	if (exception) {
-		// 		this.sendEvent(new StoppedEvent(`exception(${exception})`, MplabxDebugSession.threadID,));
-		// 	} else {
-		// 		this.sendEvent(new StoppedEvent('exception', MplabxDebugSession.threadID,));
-		// 	}
-		// });
+		this._runtime.on('stopOnException', (exception) => {
+		 	if (exception) {
+		 		this.sendEvent(new StoppedEvent(`exception(${exception})`, MplabxDebugSession.threadID,));
+		 	} else {
+		 		this.sendEvent(new StoppedEvent('exception', MplabxDebugSession.threadID,));
+		 	}
+		});
 		// this._runtime.on('breakpointValidated', (bp: IRuntimeBreakpoint) => {
 		// 	this.sendEvent(new BreakpointEvent('changed', { verified: bp.verified, id: bp.id } as DebugProtocol.Breakpoint));
 		// });
@@ -199,7 +199,7 @@ export class MplabxDebugSession extends LoggingDebugSession {
 	protected async launchRequest(response: DebugProtocol.LaunchResponse, args: ILaunchRequestArguments) {
 
 		// start the program in the runtime
-		this._runtime.startDebugger(args.program, args.configuration, !!args.stopOnEntry).then(r => {
+		this._runtime.startDebugger(args.program, args.configuration, !args.noDebug, !!args.stopOnEntry).then(r => {
 			response.success = true;
 			this.sendResponse(response);
 		}).catch(reason => {

--- a/src/debugAdapter/mplabxDebug.ts
+++ b/src/debugAdapter/mplabxDebug.ts
@@ -88,9 +88,15 @@ export class MplabxDebugSession extends LoggingDebugSession {
 		this._runtime.on('stopOnEntry', () => {
 			this.sendEvent(new StoppedEvent('entry', MplabxDebugSession.threadID,));
 		});
-		// this._runtime.on('stopOnStep', () => {
-		// 	this.sendEvent(new StoppedEvent('step', MplabxDebugSession.threadID,));
-		// });
+
+		this._runtime.on('stopOnStep', () => {
+		 	this.sendEvent(new StoppedEvent('step', MplabxDebugSession.threadID,));
+		});
+
+		this._runtime.on('stopOnPause', () => {
+			this.sendEvent(new StoppedEvent('pause', MplabxDebugSession.threadID,));
+	   });
+
 		this._runtime.on('stopOnBreakpoint', () => {
 			this.sendEvent(new StoppedEvent('breakpoint', MplabxDebugSession.threadID,));
 		});

--- a/src/debugAdapter/mplabxDebug.ts
+++ b/src/debugAdapter/mplabxDebug.ts
@@ -40,6 +40,9 @@ interface ILaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 
 	/** Automatically stop target after launch. If not specified, target does not stop. */
 	stopOnEntry?: boolean;
+
+	/** Boolean indicating whether to build and launch a debug build or a production build */
+	debug?: boolean;
 }
 
 
@@ -199,7 +202,7 @@ export class MplabxDebugSession extends LoggingDebugSession {
 	protected async launchRequest(response: DebugProtocol.LaunchResponse, args: ILaunchRequestArguments) {
 
 		// start the program in the runtime
-		this._runtime.startDebugger(args.program, args.configuration, !args.noDebug, !!args.stopOnEntry).then(r => {
+		this._runtime.startDebugger(args.program, args.configuration, args.debug, !!args.stopOnEntry).then(r => {
 			response.success = true;
 			this.sendResponse(response);
 		}).catch(reason => {


### PR DESCRIPTION
This PR introduces proper support for exception handling via keeping internal state of breakpoints inside the MDB communications instance.

Additionally, the stack frames being parsed were not including potential address-only frames.
Finally, the debug build was technically implemented, but there was no way of setting it up, which I've also added, along with properly denoting the `configuration` field in the initial configuration and configuration snippets.