### PR TITLE
Set default programmerToolAllowList to ".*"

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,9 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": [
+              ".*"
+            ],
             "description": "A list of regular expressions for programer settings to use from the MPLABX Project file (e.g. 'poweroptions.powerenable', 'voltagevalue'). Use '.*' to send all",
             "scope": "machine-overridable"
           }


### PR DESCRIPTION
The documentation specifies that :

> All programer settings are pulled from the project file in nbproject/configuration.xml. This includes what tool to use and any voltage settings. If programer settings need to be changed, it is recommended to change them from withing MPLABX to prevent corrupting the project.

However, the default settings for `programmerToolAllowList` is `[]`, which does not implement this behavior correctly. This setting should default to `[".*"]` to comply with the documnetation.