### PR TITLE
Add mdb server mode, fix old mplab on win11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ mock-debug.txt
 *.vsix
 
 package-lock.json
+bun.lockb
 
 # MacOS Directory folder
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -60,6 +60,10 @@
       {
         "command": "vslabx.listAttachedTools",
         "title": "MDB: List Attached Tools"
+      },
+      {
+        "command": "vslabx.killAllMdb",
+        "title": "MPLABX: Kill all mdb debug server"
       }
     ],
     "breakpoints": [
@@ -171,13 +175,17 @@
                 "type": "boolean",
                 "description": "Boolean indicating debug build or production build"
               },
+              "preLaunchOnRestart": {
+                "type": "boolean",
+                "description": "Boolean indicating whether to execute task when the debugger is restarted"
+              },
               "oldFileType": {
                 "type": "boolean",
                 "description": "True if using old MPLAB v5.2.X"
               },
-              "preLaunchOnRestart": {
+              "runMdbAsServer": {
                 "type": "boolean",
-                "description": "Boolean indicating whether to build when the debugger restarts"
+                "description": "Boolean indicates whether to enable mdb server mode. (It can reduce mdb starting time)"
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -142,8 +142,6 @@
           "asm"
         ],
         "label": "MPLABX Debug",
-        "program": "./out/mdbDebugAdapter.js",
-        "runtime": "node",
         "configurationAttributes": {
           "launch": {
             "required": [
@@ -172,6 +170,14 @@
               "debug": {
                 "type": "boolean",
                 "description": "Boolean indicating debug build or production build"
+              },
+              "oldFileType": {
+                "type": "boolean",
+                "description": "True if using old MPLAB v5.2.X"
+              },
+              "preLaunchOnRestart": {
+                "type": "boolean",
+                "description": "Boolean indicating whether to build when the debugger restarts"
               }
             }
           }
@@ -216,8 +222,6 @@
           "asm"
         ],
         "label": "Microchip Debug Adapter",
-        "program": "./out/mdbDebugAdapter.js",
-        "runtime": "node",
         "configurationAttributes": {
           "launch": {
             "required": [

--- a/package.json
+++ b/package.json
@@ -455,9 +455,11 @@
     "@types/mocha": "^10.0.6",
     "@types/node": "18.x",
     "@types/sinon": "^17.0.3",
+    "@types/vscode": "^1.83.0",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
     "@typescript-eslint/parser": "^6.19.1",
     "@vscode/debugadapter-testsupport": "^1.63.0",
+    "@vscode/debugprotocol": "^1.67.0",
     "@vscode/test-cli": "^0.0.6",
     "@vscode/test-electron": "^2.3.9",
     "@vscode/vsce": "^2.23.0",
@@ -466,7 +468,6 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@types/vscode": "^1.83.0",
     "@vscode/debugadapter": "^1.63.0",
     "async-mutex": "^0.4.1",
     "await-notify": "^1.0.1",

--- a/src/common/configFileHelper.ts
+++ b/src/common/configFileHelper.ts
@@ -19,7 +19,7 @@ interface TargetInterface {
     tool: string;
 
     /** Additional options to send to the tool when connecting to the device */
-    toolOptions: {};
+    toolOptions: [string, string][];
 }
 
 /** A collection of methods to use when working with MPLABX configuration.xml files */
@@ -119,16 +119,15 @@ export class MplabxConfigFile {
 
         const tool = conf.toolsSet.platformTool;
 
-        const toolOptions = {};
+        const toolOptions: [string, string][] = [];
 
         // Collect all the tool settings
         if (conf[tool]) {
-
-            conf[tool].property.forEach((pair) => {
+            for (const pair of conf[tool].property) {
                 const key: string = pair.key;
                 const value: string = pair.value;
-                toolOptions[key] = value;
-            });
+                toolOptions.push([key, value]);
+            };
         }
 
         // Get the tool

--- a/src/debugAdapter/activateMplabxDebug.ts
+++ b/src/debugAdapter/activateMplabxDebug.ts
@@ -223,6 +223,7 @@ async function convertDebugConfiguration(args: MplabxDebugConfiguration): Promis
 				stopOnEntry: args.stopOnEntry,
 				preLaunchTask: args.preLaunchOnRestart ? args.preLaunchTask : null,
 				preLaunchOnRestart: args.preLaunchOnRestart,
+				runMdbAsServer: args.runMdbAsServer,
 			};
 
 		} else {

--- a/src/debugAdapter/activateMplabxDebug.ts
+++ b/src/debugAdapter/activateMplabxDebug.ts
@@ -42,10 +42,12 @@ export interface MplabxDebugConfiguration extends DebugConfiguration {
 	debug?: boolean;
 	/** A task to run before running the debugger */
 	preLaunchTask?: string;
-	/** Boolean indicating whether to build when the debugger restarts */
+	/** Boolean indicating whether to execute task when the debugger is restarted */
 	preLaunchOnRestart?: boolean;
-	/** Boolean using old file type '.cof' */
+	/** Boolean indicating whether to use older file type '.cof' */
 	oldFileType?: boolean;
+	/** Boolean indicates whether to enable mdb server mode. (It can reduce mdb starting time) */
+	runMdbAsServer?: boolean;
 }
 
 /**

--- a/src/debugAdapter/activateMplabxDebug.ts
+++ b/src/debugAdapter/activateMplabxDebug.ts
@@ -167,12 +167,14 @@ async function convertDebugConfiguration(args: MplabxDebugConfiguration): Promis
 		if (task) {
 			const taskExecution = await vscode.tasks.executeTask(task);
 			const exitCode = await waitForTaskCompletion(taskExecution);
-			if (exitCode !== 0)
+			if (exitCode !== 0) {
 				throw new Error(`Build task end with code: ${exitCode}`);
-		} else
+			}
+		} else {
 			throw new Error(`PreLaunchTask label "${args.preLaunchTask}" not found in tasks.json`);
+		}
 	}
-
+	
 	if (fs.existsSync(outputFolder)) {
 		let outputFiles = fs.readdirSync(outputFolder, { withFileTypes: true })
 			.filter(item => item.isFile())

--- a/src/debugAdapter/activateMplabxDebug.ts
+++ b/src/debugAdapter/activateMplabxDebug.ts
@@ -61,7 +61,7 @@ export interface MdbDebugConfiguration extends DebugConfiguration {
 	/** The absolute path to the .elf file used for debugging */
 	filePath: string;
 	/** A dictionary of tool options to set. See the MPLABX configuration file for what is available*/
-	toolOptions?: any;
+	toolOptions?: [string, string][];
 	/** Automatically stop after launch.*/
 	stopOnEntry?: boolean;
 	/** Enable logging of the Debug Adapter Protocol */
@@ -162,7 +162,7 @@ async function convertDebugConfiguration(args: MplabxDebugConfiguration): Promis
 	const fileType: string = args.oldFileType ? '.cof' : '.elf';
 
 	// The output folder might not exist yet because the preLaunchTask hasn't ran yet
-	if (args.preLaunchTask) {
+	if (args.preLaunchTask && !fs.existsSync(outputFolder)) {
 		const task = (await vscode.tasks.fetchTasks()).find((t => t.name === args.preLaunchTask));
 		if (task) {
 			const taskExecution = await vscode.tasks.executeTask(task);
@@ -183,26 +183,23 @@ async function convertDebugConfiguration(args: MplabxDebugConfiguration): Promis
 		if (outputFiles.length > 0) {
 			let outputFile = outputFiles[0].name;
 
-			const programerAllowArray = vscode.workspace.getConfiguration('vslabx').get<string[]>('programerToolAllowList');
-			const programerAllowRegExp: RegExp | undefined = programerAllowArray && programerAllowArray.length > 0 ?
-				RegExp(`(${programerAllowArray?.join('|')})`) : undefined;
+			// const programerAllowArray = vscode.workspace.getConfiguration('vslabx').get<string[]>('programerToolAllowList');
+			// const programerAllowRegExp: RegExp | undefined = programerAllowArray && programerAllowArray.length > 0 ?
+			// 	RegExp(`(${programerAllowArray?.join('|')})`) : undefined;
 
-			let toolOptions: any = {};
+			let toolOptions: [string, string][] = [];
 
 			// Collect all the tool settings
-			if (targetConfig.toolOptions && programerAllowRegExp) {
-				const allowRegex: RegExp = programerAllowRegExp;
+			if (targetConfig.toolOptions) {
+				// const allowRegex: RegExp = programerAllowRegExp;
 
-				for (const key in targetConfig.toolOptions) {
+				for (const [key, value] of targetConfig.toolOptions) {
 					// Keys with a capital value don't work
 					if (key.toLowerCase() === key) {
-						const value: string = targetConfig.toolOptions[key];
-
 						// Values with '{' in it, needs resolved... idk how to do
-						if (value.length > 0 && !value.match(/(\$\{.+\}|Press\sto|system settings|\.\D)/) &&
-							key.match(allowRegex)) {
-
-							toolOptions[key] = value;
+						if (value.length > 0 && !value.match(/(\$\{.+\}|Press\sto|system settings|\.\D)/)) {
+							// key.match(allowRegex)
+							toolOptions.push([key, value]);
 						}
 					}
 				};

--- a/src/debugAdapter/mdbCommunications.ts
+++ b/src/debugAdapter/mdbCommunications.ts
@@ -153,7 +153,7 @@ export class MDBCommunications extends EventEmitter {
 		// (Windows Compatibility) Trim off quotes if there are any
 		mdbPath = mdbPath.replace(/"/g, "",);
 
-		this._mdbProcess = spawn('"' + mdbPath + '"', [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true });
+		this._mdbProcess = spawn(`"${mdbPath}"`, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true });
 		this.logLine(`--- Started Microchip Debugger ---`, LogLevel.info);
 
 		this._mdbProcess.stderr?.on('data', (error) => {
@@ -168,8 +168,9 @@ export class MDBCommunications extends EventEmitter {
 			msgPart += d;
 			if (msgPart.match(/Stop at/g)) {
 				// Return if message not complete
-				if (await this.handleStopAt(msgPart))
+				if (await this.handleStopAt(msgPart)) {
 					return;
+				}
 			}
 			// Reset message part
 			msgPart = '';
@@ -511,13 +512,14 @@ export class MDBCommunications extends EventEmitter {
 			this.lastRegisters = [];
 			for (const regName of regs) {
 				const regVal = (await this.query('Print /x ' + regName, ConnectionLevel.programed)).match(/(\w+)=([0-9a-f]+)/);
-				if (regVal?.length === 3)
+				if (regVal?.length === 3) {
 					this.lastRegisters.push({
 						name: regName,
 						value: '0x' + regVal[2],
 						presentationHint: { kind: 'data' },
 						variablesReference: 0,
 					});
+				}
 			}
 			// TODO: https://marketplace.visualstudio.com/items?itemName=mcu-debug.memory-view
 
@@ -551,18 +553,20 @@ export class MDBCommunications extends EventEmitter {
 				};
 			}
 			// When using old mplab, backtrace maybe empty
-			if (stackMatches.length === 0 && this._lastStop)
+			if (stackMatches.length === 0 && this._lastStop) {
 				return [{
 					index: 0,
 					name: 'Unknown',
 					file: this._lastStop[0],
 					line: this._lastStop[1]
 				}];
+			}
+
 			return stack;
 		});
 	}
 
-public get hasRegisters(): boolean {
+	public get hasRegisters(): boolean {
 		return this.lastRegisters.length > 0;
 	}
 
@@ -572,7 +576,7 @@ public get hasRegisters(): boolean {
 
 	public get hasParameters(): boolean {
 			return this.lastParameters.length > 0;
-		}
+	}
 
 	public async getRegisters(): Promise<Array<DebugProtocol.Variable>> {
 		return this.lastRegisters;

--- a/src/debugAdapter/mdbCommunications.ts
+++ b/src/debugAdapter/mdbCommunications.ts
@@ -121,6 +121,10 @@ export class MDBCommunications extends EventEmitter {
 
 	private _emitter: EventEmitter = new EventEmitter();
 
+	public isDisposed(): boolean {
+		return this.disposed;
+	}
+
 	private get connectionLevel(): ConnectionLevel {
 		return this._connectionLevel;
 	}

--- a/src/debugAdapter/mdbCommunications.ts
+++ b/src/debugAdapter/mdbCommunications.ts
@@ -392,7 +392,7 @@ export class MDBCommunications extends EventEmitter {
 		});
 	}
 
-	public async connect(targetDevice: string, toolSet: string, programMode: boolean, toolSetOptions: object = {}): Promise<ConnectionType> {
+	public async connect(targetDevice: string, toolSet: string, programMode: boolean, toolSetOptions: [string, string][] = []): Promise<ConnectionType> {
 
 		this.write(`Device ${targetDevice}`, ConnectionLevel.none);
 
@@ -400,8 +400,12 @@ export class MDBCommunications extends EventEmitter {
 
 		// Apply all the tool settings
 		if (toolSetOptions) {
-			for (const [key, value] of Object.entries(toolSetOptions)) {
-				this.query(`set ${key} ${value}`, ConnectionLevel.deviceSet);
+			for (const [key, value] of toolSetOptions) {
+				const result = (await this.query(`set ${key} ${value}`, ConnectionLevel.deviceSet))
+					.replace(/^\>+|\>+$/g, '');
+				// if (result.match(/Error: /)) {
+				// 	window.showErrorMessage(`${result} ${key} ${value}`);
+				// }
 			};
 		}
 
@@ -424,15 +428,17 @@ export class MDBCommunications extends EventEmitter {
 		return result;
 	}
 
-	public async startDebugger(targetDevice: string, toolSet: string, elfFile: string, toolSetOptions: object = {}, stopOnEntry = false) {
-
+	public startDebugger(targetDevice: string, toolSet: string, elfFile: string, toolSetOptions: [string, string][] = [], stopOnEntry = false): Promise<void> {
 		if (!fs.existsSync(elfFile)) {
 			throw new Error(`Failure to find the given file: ${elfFile}`);
 		}
+		this._elfFile = elfFile;
+		return this.connect(targetDevice, toolSet, false, toolSetOptions).then((connectionType) => this.programDevice());
+		}
 
-		return this.connect(targetDevice, toolSet, false, toolSetOptions).then(async (connectionType) => {
+	public async programDevice() {
 			// Program the chip
-			const programResult = await this.query(`Program "${elfFile}"`, ConnectionLevel.connected);
+		const programResult = await this.query(`Program "${this._elfFile}"`, ConnectionLevel.connected);
 			if (programResult.match(/Program succeeded\./) || programResult.match(/Programming\/Verify complete/)) {
 
 				this.connectionLevel = ConnectionLevel.programed;
@@ -443,7 +449,6 @@ export class MDBCommunications extends EventEmitter {
 			} else {
 				throw new Error('Failure to write program to device');
 			}
-		});
 	}
 
 	public clearBreakpoints() {

--- a/src/debugAdapter/mdbCommunications.ts
+++ b/src/debugAdapter/mdbCommunications.ts
@@ -11,8 +11,9 @@ import fs = require('fs');
 import { EventEmitter } from 'stream';
 import { debug } from 'console';
 import { normalizePath } from '../common/mdbPaths';
+import { window } from 'vscode';
 
-enum ConnectionLevel {
+export enum ConnectionLevel {
 	none,
 	deviceSet,
 	connected,
@@ -112,6 +113,7 @@ export class MDBCommunications extends EventEmitter {
 	private _mdbProcess: ChildProcess;
 	private _mdbLogger: ILogWriter | undefined;
 	private _mdbMutex: Mutex = new Mutex();
+	private _elfFile: string = '';
 
 	private _breakpoints: IBreakpoint[] = [];
 	private _haltReason: HaltReason = HaltReason.none;
@@ -413,14 +415,28 @@ export class MDBCommunications extends EventEmitter {
 		let message: string = await this.query(`HwTool ${toolSet}${programMode ? ' -p' : ''}`, ConnectionLevel.deviceSet, '>');
 
 		// If message is just the default > output, keep reading. On different platforms, \r\n> may be the case, but we're looking for a longer string anyway.
-		if (message.length < 8) {
-			message = await this.readResult('>');
+		if (message.length < 8)
+			message = await this.readResult();
+		message = message.replace(/^\>+|\>+$|^\s*\**\s*/g, '').trim();
+
+		// If get warning ask if continue
+		const warningMessage = message.match(/CAUTION: ([^^]+)/)
+		if (warningMessage && warningMessage[1]) {
+			const messageBody = warningMessage[1];
+			if (!messageBody.includes('Selecting a 5V device when a 3.3V')) {
+				// Ask user if wnat to continue
+				const result = await window.showWarningMessage(messageBody, 'Continue');
+				if (result !== 'Continue')
+					throw new Error(`Failed to connect to target device\n${message}`);
+			}
+			message = (await this.query('yes', ConnectionLevel.deviceSet))
+				.replace(/^\>+|\>+$|^\s*\**\s*/g, '').trim();;
 		}
 
 		let result: ConnectionType = toolSet === "Sim" ? ConnectionType.simulator : ConnectionType.hardware;
 
 		if (result === ConnectionType.hardware && !message.match(/Target device (.+) found\./)) {
-			throw new Error(`Failed to connect to target device ${message.replace(/^\>+|\>+$/g, '').trim()}`);
+			throw new Error(`Failed to connect to target device\n${message}`);
 		}
 
 		this.connectionLevel = ConnectionLevel.connected;

--- a/src/debugAdapter/mdbCommunications.ts
+++ b/src/debugAdapter/mdbCommunications.ts
@@ -526,8 +526,6 @@ export class MDBCommunications extends EventEmitter {
 					});
 				}
 			}
-			// TODO: https://marketplace.visualstudio.com/items?itemName=mcu-debug.memory-view
-
 			let parametersMatch = [...response.matchAll(/\s+(\w+)=0x(\d+)/g)];
 
 			this.lastParameters = parametersMatch.map((m, i) => {

--- a/src/debugAdapter/mdbCommunications.ts
+++ b/src/debugAdapter/mdbCommunications.ts
@@ -163,16 +163,19 @@ export class MDBCommunications extends EventEmitter {
 		});
 
 		let msgPart: string = '';
-		this._mdbProcess.stdout?.on('data', async (data: String) => {
-			let d: string = `${data}`;
-			this.log(d, LogLevel.read);
+		this._mdbProcess.stdout?.on('data', async (raw: Buffer) => {
+			const data = raw.toString().replace(/^\>+|\>+$/g, '');
 
-			msgPart += d;
+			msgPart += data;
 			if (msgPart.match(/Stop at/g)) {
 				// Return if message not complete
 				if (await this.handleStopAt(msgPart)) {
 					return;
 				}
+				this.logLine(msgPart.trim(), LogLevel.read);
+			} else {
+				const msg = data.trim();
+				this.logLine(msg, LogLevel.read);
 			}
 			// Reset message part
 			msgPart = '';
@@ -181,6 +184,7 @@ export class MDBCommunications extends EventEmitter {
 		this._mdbProcess.on('close', (code) => {
 			this.logLine(`--- Microchip Debugger exited with code ${code} ---`,
 				code === 0 ? LogLevel.info : LogLevel.error);
+			this.disposed = true;
 		});
 
 		// Wait for the Microchip Debugger to start up.
@@ -206,7 +210,7 @@ export class MDBCommunications extends EventEmitter {
 		this.log(`${input}\r\n`, logLevel);
 	}
 
-	private _write(input: string, level: ConnectionLevel) {
+	private _write(input: string) {
 		this.mdbProcess.stdin?.write(input + '\r\n');
 		this.logLine(input, LogLevel.wrote);
 	}
@@ -214,10 +218,10 @@ export class MDBCommunications extends EventEmitter {
 	/** Writes the given command to the Microchip Debugger
 	 * @param input The command to send
 	 */
-	private write(input: string, level: ConnectionLevel) {
+	public write(input: string, level: ConnectionLevel) {
 		if (this.connectionLevel >= level) {
 			this._mdbMutex.runExclusive(() => {
-				this._write(input, level);
+				this._write(input);
 			});
 		} else {
 			this.once(level.toString(), () => this.write(input, level));
@@ -302,7 +306,7 @@ export class MDBCommunications extends EventEmitter {
 	 * @param input The command to send to the debugger
 	 * @param level The ConnectionLevel required in order for the command to work
 	 */
-	async query(input: string, level: ConnectionLevel, until: string = '>'): Promise<string> {
+	public async query(input: string, level: ConnectionLevel, until: string = '>'): Promise<string> {
 
 		if (this.connectionLevel >= level) {
 			return this._mdbMutex.runExclusive(() => {
@@ -312,7 +316,7 @@ export class MDBCommunications extends EventEmitter {
 				}
 
 				let result: Promise<string> = this.readResult(until);
-				this._write(input, level);
+				this._write(input);
 
 				return result;
 			});
@@ -468,13 +472,13 @@ export class MDBCommunications extends EventEmitter {
 	}
 
 	public clearBreakpoints() {
-		this.query('delete', ConnectionLevel.programed).then(() => {
+		this.query('Delete', ConnectionLevel.programed).then(() => {
 			this._breakpoints = [];
 		});
 	}
 
 	public clearBreakpoint(id: number) {
-		this.query(`delete ${id}`, ConnectionLevel.programed).then(() => {
+		this.query(`Delete ${id}`, ConnectionLevel.programed).then(() => {
 			this._breakpoints = this._breakpoints.filter(bp => bp.id !== id);
 		});
 	}
@@ -634,8 +638,22 @@ export class MDBCommunications extends EventEmitter {
 		this.write('Halt', ConnectionLevel.programed);
 	}
 
-	public quit(): void {
-		this.dispose();
+	public stopDebug(): Promise<void> {
+		this._haltReason = HaltReason.none;
+		// IDK why but it unlock the build output file 
+		return this.programDevice();
+	}
+
+	public quit(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			if (!this.disposed) {
+				this._mdbProcess.once('close', resolve);
+				setTimeout(this._mdbProcess.kill, 1000);
+				this._write('Quit');
+				this.disposed = true;
+			} else // Already disposed
+				resolve();
+		});
 	}
 
 	public async watch(address: string, breakOnType: BreakOnType, value?: number, passCount?: number): Promise<ISetWatchResponse> {

--- a/src/debugAdapter/mdbCommunications.ts
+++ b/src/debugAdapter/mdbCommunications.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 
 'use strict';
-import { ChildProcess, spawn } from 'child_process';
+import { ChildProcess, spawn, exec } from 'child_process';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { Mutex } from 'async-mutex';
 import path = require('path');
@@ -115,8 +115,10 @@ export class MDBCommunications extends EventEmitter {
 	private _mdbMutex: Mutex = new Mutex();
 	private _elfFile: string = '';
 
+	private _messagePart: string = '';
 	private _breakpoints: IBreakpoint[] = [];
 	private _haltReason: HaltReason = HaltReason.none;
+	/** For debugging assembly language, stacktrace will be empty */
 	private _lastStop?: [string, number];
 
 	private _connectionLevel: ConnectionLevel = ConnectionLevel.none;
@@ -154,31 +156,35 @@ export class MDBCommunications extends EventEmitter {
 
 		// (Windows Compatibility) Trim off quotes if there are any
 		mdbPath = mdbPath.replace(/"/g, "",);
-
-		this._mdbProcess = spawn(`"${mdbPath}"`, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true });
+		// https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows
+		if (process.platform === 'win32')
+			this._mdbProcess = exec(`"${mdbPath}"`);
+		else
+			this._mdbProcess = spawn(mdbPath, [], { stdio: ['pipe', 'pipe', 'pipe'] });
 		this.logLine(`--- Started Microchip Debugger ---`, LogLevel.info);
 
 		this._mdbProcess.stderr?.on('data', (error) => {
 			debug(`MDB ERROR -> ${error}`);
 		});
 
-		let msgPart: string = '';
 		this._mdbProcess.stdout?.on('data', async (raw: Buffer) => {
-			const data = raw.toString().replace(/^\>+|\>+$/g, '');
+			const data = raw.toString();
 
-			msgPart += data;
-			if (msgPart.match(/Stop at/g)) {
-				// Return if message not complete
-				if (await this.handleStopAt(msgPart)) {
-					return;
-				}
-				this.logLine(msgPart.trim(), LogLevel.read);
-			} else {
-				const msg = data.trim();
-				this.logLine(msg, LogLevel.read);
+			this._messagePart += data;
+			// Wait data chunk end 
+			if (data.lastIndexOf('>') === -1 && this.connectionLevel === ConnectionLevel.programed)
+				return;
+			// Remove extra character
+			this._messagePart = this._messagePart.replace(/>/g, '').trim();
+			if (!this._messagePart)
+				return;
+
+			if (this._messagePart.match(/Stop at/g)) {
+				await this.handleStopAt(this._messagePart);
 			}
+			this.logLine(this._messagePart, LogLevel.read);
 			// Reset message part
-			msgPart = '';
+			this._messagePart = '';
 		});
 
 		this._mdbProcess.on('close', (code) => {
@@ -266,15 +272,23 @@ export class MDBCommunications extends EventEmitter {
 	 * @param message The "Stop at" message
 	 */
 	private async handleStopAt(message: string): Promise<boolean> {
-		// const addressRegex = /address:(?<address>0x[0-9a-fA-F]{2,8})/gm;
+		// Assume we're setting this correctly and can trust it to early return if the stop is user generated in some sense
+		if (this._haltReason !== HaltReason.none) {
+			const eventToDispatch = haltReasonEventMap[this._haltReason];
+			this.emit(eventToDispatch);
+			return false; // Early return, as stopAt otherwise checks exceptions and breakpoints
+		}
+
+		const addressRegex = /address:(?<address>0x[0-9a-fA-F]{1,8})/gm;
 		const fileRegex = /file:(?<file>.+)/gm;
 		const lineRegex = /source line:(?<line>\d+)/gm;
 
 		let matches = message.match(lineRegex);
 
-		// Stop at message may or may not come in a single data or over multiple. 
-		// If we don't match the pattern, we need to keep reading and re-parse when a full message has been received.
 		if ((matches?.length || 0) < 1) {
+			// Only have address, try continue
+			if (message.match(addressRegex))
+				this.continue();
 			return true;
 		}
 
@@ -284,13 +298,6 @@ export class MDBCommunications extends EventEmitter {
 
 		if (!file || line < 0) { return false; };
 		this._lastStop = [file, line];
-
-		// Assume we're setting this correctly and can trust it to early return if the stop is user generated in some sense
-		if (this._haltReason !== HaltReason.none) {
-			const eventToDispatch = haltReasonEventMap[this._haltReason];
-			this.emit(eventToDispatch);
-			return false; // Early return, as stopAt otherwise checks exceptions and breakpoints
-		}
 
 		// Find potential breakpoint based on file name and line - if this does not exist, it must be an exception.
 		const breakpoint = this._breakpoints.find(bp => (normalizePath(bp.file) === normalizePath(file)) && bp.line === line);
@@ -355,7 +362,7 @@ export class MDBCommunications extends EventEmitter {
 					serialNumber: 'None'
 				}];
 			}
-			
+
 			return lines.map((line => {
 				let match = line.match(/(?<index>\d+)\s*(?<type>[\w\d]+)\s*(?<serialNumber>[\w\d]+)\s*(?<ipAddress>[\w\/\d]+)\s*(?<name>[\w\d\s]+)/);
 
@@ -402,6 +409,7 @@ export class MDBCommunications extends EventEmitter {
 
 		this.write(`Device ${targetDevice}`, ConnectionLevel.none);
 
+		this._messagePart = '';
 		this.connectionLevel = ConnectionLevel.deviceSet;
 
 		// Apply all the tool settings
@@ -427,12 +435,10 @@ export class MDBCommunications extends EventEmitter {
 		const warningMessage = message.match(/CAUTION: ([^^]+)/)
 		if (warningMessage && warningMessage[1]) {
 			const messageBody = warningMessage[1];
-			if (!messageBody.includes('Selecting a 5V device when a 3.3V')) {
-				// Ask user if wnat to continue
-				const result = await window.showWarningMessage(messageBody, 'Continue');
-				if (result !== 'Continue')
-					throw new Error(`Failed to connect to target device\n${message}`);
-			}
+			// Ask user if wnat to continue
+			const result = await window.showWarningMessage(messageBody, 'Continue');
+			if (result !== 'Continue')
+				throw new Error(`Failed to connect to target device\n${message}`);
 			message = (await this.query('yes', ConnectionLevel.deviceSet))
 				.replace(/^\>+|\>+$|^\s*\**\s*/g, '').trim();;
 		}
@@ -454,21 +460,21 @@ export class MDBCommunications extends EventEmitter {
 		}
 		this._elfFile = elfFile;
 		return this.connect(targetDevice, toolSet, false, toolSetOptions).then((connectionType) => this.programDevice());
-		}
+	}
 
 	public async programDevice() {
-			// Program the chip
+		// Program the chip
 		const programResult = await this.query(`Program "${this._elfFile}"`, ConnectionLevel.connected);
-			if (programResult.match(/Program succeeded\./) || programResult.match(/Programming\/Verify complete/)) {
+		if (programResult.match(/Program succeeded\./) || programResult.match(/Programming\/Verify complete/)) {
 
-				this.connectionLevel = ConnectionLevel.programed;
+			this.connectionLevel = ConnectionLevel.programed;
 
-				// Let everyone know initialization has completed.
-				this.emit('initCompleted');
+			// Let everyone know initialization has completed.
+			this.emit('initCompleted');
 
-			} else {
-				throw new Error('Failure to write program to device');
-			}
+		} else {
+			throw new Error('Failure to write program to device');
+		}
 	}
 
 	public clearBreakpoints() {
@@ -533,19 +539,6 @@ export class MDBCommunications extends EventEmitter {
 					variablesReference: 0,
 				};
 			});
-			const regs = ['WREG', 'FSR0', 'FSR1', 'FSR2'];
-			this.lastRegisters = [];
-			for (const regName of regs) {
-				const regVal = (await this.query('Print /x ' + regName, ConnectionLevel.programed)).match(/(\w+)=([0-9a-f]+)/);
-				if (regVal?.length === 3) {
-					this.lastRegisters.push({
-						name: regName,
-						value: '0x' + regVal[2],
-						presentationHint: { kind: 'data' },
-						variablesReference: 0,
-					});
-				}
-			}
 			let parametersMatch = [...response.matchAll(/\s+(\w+)=0x(\d+)/g)];
 
 			this.lastParameters = parametersMatch.map((m, i) => {
@@ -594,11 +587,11 @@ export class MDBCommunications extends EventEmitter {
 	}
 
 	public get hasLocalVariables(): boolean {
-			return this.lastLocals.length > 0;
+		return this.lastLocals.length > 0;
 	}
 
 	public get hasParameters(): boolean {
-			return this.lastParameters.length > 0;
+		return this.lastParameters.length > 0;
 	}
 
 	public async getRegisters(): Promise<Array<DebugProtocol.Variable>> {
@@ -689,10 +682,10 @@ export class MDBCommunications extends EventEmitter {
 
 	public async printVariable(name: string): Promise<DebugProtocol.Variable | undefined> {
 
-		const hexMatch = name.match(/^0x([\dA-Fa-f]+)$/);
-		if (hexMatch) {
-			name = parseInt(hexMatch[1]).toString();
-		}
+		// const hexMatch = name.match(/^0x([\dA-Fa-f]+)$/);
+		// if (hexMatch) {
+		// 	name = parseInt(hexMatch[1]).toString();
+		// }
 
 		return this.query(`Print ${name}`, ConnectionLevel.programed).then(response => {
 			const re = response.match(/(\w+)=\n?(\d+)/);
@@ -707,13 +700,5 @@ export class MDBCommunications extends EventEmitter {
 				return undefined;
 			}
 		});
-	}
-
-	/** Disposes the assistant */
-	public dispose() {
-		if (!this.disposed && this._mdbProcess) {
-			this._write('Quit', ConnectionLevel.none);
-		}
-		this.disposed = true;
 	}
 }

--- a/src/debugAdapter/mplabxDebug.ts
+++ b/src/debugAdapter/mplabxDebug.ts
@@ -791,8 +791,9 @@ export class MdbDebugSession extends LoggingDebugSession {
 	}
 
 	shutdown(force: boolean = false) {
-		if (force || !this._isServer && !this._isRunningInline() && !this._runtime.isDisposed())
+		if (force || !this._isServer && !this._isRunningInline() && !this._runtime.isDisposed()) {
 			this._runtime.quit();
+		}
 		super.shutdown();
 	}
 

--- a/src/debugAdapter/mplabxDebug.ts
+++ b/src/debugAdapter/mplabxDebug.ts
@@ -786,8 +786,14 @@ export class MdbDebugSession extends LoggingDebugSession {
 	// }
 
 	protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments, request?: DebugProtocol.Request): void {
-		this._runtime.quit();
+		this.shutdown();
 		this.sendResponse(response);
+	}
+
+	shutdown(force: boolean = false) {
+		if (force || !this._isServer && !this._isRunningInline() && !this._runtime.isDisposed())
+			this._runtime.quit();
+		super.shutdown();
 	}
 
 	//---- helpers

--- a/src/debugAdapter/mplabxDebug.ts
+++ b/src/debugAdapter/mplabxDebug.ts
@@ -21,7 +21,7 @@ import {
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { basename } from 'path-browserify';
 import { Subject } from 'await-notify';
-import { MDBCommunications } from './mdbCommunications';
+import { ConnectionLevel, MDBCommunications } from './mdbCommunications';
 import { MPLABXPaths } from '../common/mplabPaths';
 
 /**
@@ -193,11 +193,9 @@ export class MdbDebugSession extends LoggingDebugSession {
 	}
 
 	protected async launchRequest(response: DebugProtocol.LaunchResponse, args: ILaunchRequestArguments) {
-
 		try {
 			// start the program in the runtime
 			this._runtime.startDebugger(args.device, args.toolType, args.filePath, args.toolOptions).then(r => {
-				
 				this._stopOnEntry = !!args.stopOnEntry;
 				response.success = true;
 				this.sendResponse(response);
@@ -500,10 +498,15 @@ export class MdbDebugSession extends LoggingDebugSession {
 	protected async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): Promise<void> {
 
 		let reply: string | undefined;
-		let rv: Variable | undefined;
-
 		switch (args.context) {
-			// case 'repl':
+			case 'repl':
+				const result = await this._runtime.query(args.expression, ConnectionLevel.connected);
+				response.body = {
+					result: result,
+					variablesReference: 0
+				};
+				this.sendResponse(response);
+				return;
 			// 	// handle some REPL commands:
 			// 	// 'evaluate' supports to create and delete breakpoints from the 'repl':
 			// 	const matches = /new +([0-9]+)/.exec(args.expression);
@@ -541,8 +544,15 @@ export class MdbDebugSession extends LoggingDebugSession {
 			case 'watch':
 				let watch = await this._runtime.printVariable(args.expression);
 
+				let rv: Variable | undefined;
 				if (watch) {
 					rv = new Variable(watch.name, watch.value.toString());
+					response.body = {
+						result: rv.value,
+						variablesReference: rv.variablesReference
+					};
+					this.sendResponse(response);
+					return;
 				} else {
 					reply = 'Out of Scope';
 				}
@@ -557,17 +567,10 @@ export class MdbDebugSession extends LoggingDebugSession {
 			// 	break;
 		}
 
-		if (rv) {
-			response.body = {
-				result: rv.value,
-				variablesReference: rv.variablesReference
-			};
-		} else {
-			response.body = {
-				result: reply ? reply : 'Unknown Expression',
-				variablesReference: 0
-			};
-		}
+		response.body = {
+			result: reply ? reply : 'Unknown Expression',
+			variablesReference: 0
+		};
 
 		this.sendResponse(response);
 	}
@@ -786,15 +789,17 @@ export class MdbDebugSession extends LoggingDebugSession {
 	// }
 
 	protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments, request?: DebugProtocol.Request): void {
-		this.shutdown();
-		this.sendResponse(response);
+		if (this._isServer || this._isRunningInline()) {
+			this._runtime.stopDebug().then(() => this.sendResponse(response));
+		} else
+			this.sendResponse(response);
 	}
 
-	shutdown(force: boolean = false) {
+	shutdown(force: boolean = false): void {
 		if (force || !this._isServer && !this._isRunningInline() && !this._runtime.isDisposed()) {
-			this._runtime.quit();
-		}
-		super.shutdown();
+			this._runtime.quit().then(super.shutdown);
+		} else
+			super.shutdown();
 	}
 
 	//---- helpers

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -224,17 +224,16 @@ class MdbDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterDescr
 			this.server = Net.createServer(socket => {
 				let debugSession: MdbDebugSession;
 				const configArgs = session.configuration as MplabxDebugConfiguration;
+				
 				if (configArgs.type === 'mdb' && configArgs.runMdbAsServer) {
-					let d = mdbDebugSession.get(session.name);
-					if (!d)
-						mdbDebugSession.set(session.name, d = new MdbDebugSession());
-					debugSession = d;
-				debugSession.setRunAsServer(true);
+					debugSession = mdbDebugSession.get(session.name) ?? new MdbDebugSession();
+					mdbDebugSession.set(session.name, debugSession);
+					debugSession.setRunAsServer(true);
 				} else {
 					debugSession = new MdbDebugSession();
 					debugSession.setRunAsServer(false);
 				}
-
+				
 				debugSession.start(socket as NodeJS.ReadableStream, socket);
 			}).listen(0);
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -218,7 +218,6 @@ class MdbDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterDescr
 	private server?: Net.Server;
 
 	createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-		// TODO: Figure out how to close debugSession properly
 		if (!this.server) {
 			// start listening on a random port
 			this.server = Net.createServer(socket => {


### PR DESCRIPTION
I was doing a college assignment recently, we use PIC18F with the simulator.
The software we used was relatively old(MPLAB 5.20) and I had to use your Extension.
However, I found that the Extension could not run on my computer (`Error: spawn EINVAL`), and `handleStopAt` also did not work properly, so I Changed some fixes and added some features.
But I don’t know much about vscode’s Extension, so I don’t know if these modifications are reasonable. If possible, please give me some advice, I will continue to learn and update.
And I am currently planning to add memory table.

Thank u